### PR TITLE
change role_name to role

### DIFF
--- a/internal/mdxc/application_permission.go
+++ b/internal/mdxc/application_permission.go
@@ -12,7 +12,7 @@ import (
 
 type ApplicationPermissionPermissionData struct {
 	PolicyARN types.String `tfsdk:"policy_arn"`
-	RoleName  types.String `tfsdk:"role_name"`
+	Role      types.String `tfsdk:"role"`
 	Scope     types.String `tfsdk:"scope"`
 	Condition types.String `tfsdk:"condition"`
 }
@@ -113,7 +113,7 @@ type applicationPermissionFunctionAzure func(context.Context, *azure.Application
 func convertApplicationPermissionConfigTerraformToAzure(d *ApplicationPermissionData, a *azure.ApplicationPermissionConfig) {
 	a.ID = d.Id.Value
 	if d.Permission != nil {
-		a.RoleName = d.Permission.RoleName.Value
+		a.RoleName = d.Permission.Role.Value
 		a.Scope = d.Permission.Scope.Value
 	}
 }
@@ -123,7 +123,7 @@ func convertApplicationPermissionConfigAzureToTerraform(a *azure.ApplicationPerm
 	if d.Permission == nil {
 		d.Permission = &ApplicationPermissionPermissionData{}
 	}
-	d.Permission.RoleName = types.String{Value: a.RoleName}
+	d.Permission.Role = types.String{Value: a.RoleName}
 	d.Permission.Scope = types.String{Value: a.Scope}
 }
 
@@ -164,7 +164,7 @@ func convertApplicationPermissionConfigTerraformToGCP(d *ApplicationPermissionDa
 	a.Project = c.Provider.Project.Value
 	a.ServiceAccountID = d.ApplicationIdentityID.Value
 	if d.Permission != nil {
-		a.Role = d.Permission.RoleName.Value
+		a.Role = d.Permission.Role.Value
 		a.Condition = d.Permission.Condition.Value
 	}
 }
@@ -174,7 +174,7 @@ func convertApplicationPermissionConfigGCPToTerraform(a *gcp.ApplicationPermissi
 	if d.Permission == nil {
 		d.Permission = &ApplicationPermissionPermissionData{}
 	}
-	d.Permission.RoleName = types.String{Value: a.Role}
+	d.Permission.Role = types.String{Value: a.Role}
 	d.ApplicationIdentityID = types.String{Value: a.ServiceAccountID}
 	d.Permission.Condition = types.String{Value: a.Condition}
 }

--- a/internal/provider/resource_application_permission.go
+++ b/internal/provider/resource_application_permission.go
@@ -52,13 +52,13 @@ func (t ResourceApplicationPermissionType) GetSchema(ctx context.Context) (tfsdk
 						},
 						Validators: []tfsdk.AttributeValidator{
 							schemavalidator.ConflictsWith(
-								path.MatchRelative().AtParent().AtName("role_name"),
+								path.MatchRelative().AtParent().AtName("role"),
 								path.MatchRelative().AtParent().AtName("scope"),
 								path.MatchRelative().AtParent().AtName("condition"),
 							),
 						},
 					},
-					"role_name": {
+					"role": {
 						Type:        types.StringType,
 						Optional:    true,
 						Description: "The Azure or GCP built-in IAM role to bind to the application identity",
@@ -85,7 +85,7 @@ func (t ResourceApplicationPermissionType) GetSchema(ctx context.Context) (tfsdk
 								path.MatchRelative().AtParent().AtName("condition"),
 							),
 							schemavalidator.AlsoRequires(
-								path.MatchRelative().AtParent().AtName("role_name"),
+								path.MatchRelative().AtParent().AtName("role"),
 							),
 						},
 					},
@@ -102,7 +102,7 @@ func (t ResourceApplicationPermissionType) GetSchema(ctx context.Context) (tfsdk
 								path.MatchRelative().AtParent().AtName("scope"),
 							),
 							schemavalidator.AlsoRequires(
-								path.MatchRelative().AtParent().AtName("role_name"),
+								path.MatchRelative().AtParent().AtName("role"),
 							),
 						},
 					},


### PR DESCRIPTION
The value being passed to the `permission` field on the permission resource is coming directly from the iam security block. GCP and Azure use `role`  instead of `role_name` so this breaks when the artifact security block has `role`.


GCP: https://github.com/massdriver-cloud/artifact-definitions/blob/main/definitions/types/gcp-security-iam.json#L14
Azure: https://github.com/massdriver-cloud/artifact-definitions/blob/main/definitions/types/azure-security-iam.json#L15

<img width="1397" alt="Screenshot 2022-09-01 at 11 22 05 AM" src="https://user-images.githubusercontent.com/651833/187985595-49964def-8e68-4628-b07b-94e18e1d9fb3.png">
