### PR TITLE
add retry helper to GCP SA create

### DIFF
--- a/internal/cloud/gcp/application_identity.go
+++ b/internal/cloud/gcp/application_identity.go
@@ -61,9 +61,9 @@ func CreateApplicationIdentity(ctx context.Context, config *ApplicationIdentityC
 	if doErr != nil {
 		return doErr
 	}
-	resourceName := fmt.Sprintf("projects/%s/serviceAccounts/%s", config.Project, serviceAccount.Email)
+	resourceID := fmt.Sprintf("projects/%s/serviceAccounts/%s", config.Project, serviceAccount.Email)
 	err := retry(5, time.Second, func() (operr error) {
-		_, errGet := client.Get(resourceName).Do()
+		_, errGet := client.Get(resourceID).Do()
 		return errGet
 	})
 	if err != nil {

--- a/internal/cloud/gcp/utils.go
+++ b/internal/cloud/gcp/utils.go
@@ -1,0 +1,25 @@
+package gcp
+
+import (
+	"time"
+)
+
+type stop struct {
+	error
+}
+
+func retry(attempts int, sleep time.Duration, fn func() error) error {
+	if err := fn(); err != nil {
+		if s, ok := err.(stop); ok {
+			// Return the original error for later checking
+			return s.error
+		}
+
+		if attempts--; attempts > 0 {
+			time.Sleep(sleep)
+			return retry(attempts, 2*sleep, fn)
+		}
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Ran into this with a customer, but on service account creation. Service accounts are eventually consistent so I added a retry helper and tested it locally. I wasn't able to reproduce the issue after that.

resolves: https://github.com/massdriver-cloud/terraform-provider-mdxc/issues/29