### PR TITLE
bump goreleaser to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           gpg_private_key: ${{ secrets.TERRAFORM_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.TERRAFORM_GPG_PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         with:
           args: release --rm-dist
         env:


### PR DESCRIPTION
There was a change with the GitHub URL support for releases, which breaks goreleaser. The discussion is [here](https://github.com/goreleaser/goreleaser-action/pull/390). This was fixed ~20 minutes ago.

As far as I can tell, the only breaking change between v3 and v4 is a feature that we don't use.