### PR TITLE
Fix GCP permissions not binding due to version issues

### DIFF
--- a/internal/cloud/gcp/application_permission.go
+++ b/internal/cloud/gcp/application_permission.go
@@ -102,7 +102,8 @@ func getProjectIamPolicy(ctx context.Context, service GCPResourceManagerIface, p
 	if errDo != nil {
 		return nil, errDo
 	}
-
+	// The "RequestedPolicyVersion" above isn't guaranteeing version 3, so we force it here
+	policy.Version = 3
 	return policy, nil
 }
 
@@ -140,6 +141,9 @@ func removeFromPolicy(ctx context.Context, config *ApplicationPermissionConfig, 
 
 	policy.Bindings = thirdparty.RemoveBinding(policy.Bindings, &cloudresourcemanager.Binding{
 		Role: role,
+		Condition: &cloudresourcemanager.Expr{
+			Expression: config.Condition,
+		},
 		Members: []string{
 			fmt.Sprintf("serviceAccount:%s", member),
 		},


### PR DESCRIPTION
This addresses an issue where new GCP projects can't bind Roles to Service Accounts with:

```
Error 400: Specified policy version (1) must be at least 3 based on the policy's contents. For more information, please refer to https://cloud.google.com/iam/help/allow-policies/versions., badRequest
```