### PR TITLE
Add forcenew to assume_role_policy on AWS role

### DIFF
--- a/internal/provider/resource_application_identity.go
+++ b/internal/provider/resource_application_identity.go
@@ -28,6 +28,9 @@ var awsApplicationIdentityInputs = tfsdk.Attribute{
 			Type:        types.StringType,
 			Description: "The AWS IAM role assume role policy. Required if provisioning into AWS",
 			Required:    true,
+			PlanModifiers: tfsdk.AttributePlanModifiers{
+				resource.RequiresReplace(),
+			},
 		},
 	}),
 }


### PR DESCRIPTION
* This helps us avoid Read/Update on AWS role which is quite complicated. The only situation where this should arise, a brief interruption of service (from deleting the old role and creating the new role) should be negligible.